### PR TITLE
vppcfg: add args to specify location of vpp api files

### DIFF
--- a/vpp/dumper.py
+++ b/vpp/dumper.py
@@ -31,8 +31,13 @@ class Dumper(VPPApi):
     Note that not all running VPP configs are "valid" in vppcfg's eyes. It is not
     guaranteed that the output of the Dumper() will stand validation."""
 
-    def __init__(self, address="/run/vpp/api.sock", clientname="vppcfg"):
-        VPPApi.__init__(self, address, clientname)
+    def __init__(
+        self,
+        vpp_api_socket="/run/vpp/api.sock",
+        vpp_json_dir="/usr/share/vpp/api/",
+        clientname="vppcfg",
+    ):
+        VPPApi.__init__(self, vpp_api_socket, vpp_json_dir, clientname)
 
     def write(self, outfile):
         """Emit the configuration to either stdout (outfile=='-') or a filename"""

--- a/vpp/reconciler.py
+++ b/vpp/reconciler.py
@@ -38,11 +38,11 @@ class Reconciler:
     but not yet in the dataplane; and finally it syncs the configuration attributes of
     objects that can be changed at runtime."""
 
-    def __init__(self, cfg):
+    def __init__(self, cfg, vpp_api_socket='/run/vpp/api.sock', vpp_json_dir='/usr/share/vpp/api/'):
         self.logger = logging.getLogger("vppcfg.reconciler")
         self.logger.addHandler(logging.NullHandler())
 
-        self.vpp = VPPApi()
+        self.vpp = VPPApi(vpp_api_socket, vpp_json_dir)
         self.cfg = cfg
 
         ## List of CLI calls emitted during the prune, create and sync phases.

--- a/vpp/reconciler.py
+++ b/vpp/reconciler.py
@@ -38,7 +38,12 @@ class Reconciler:
     but not yet in the dataplane; and finally it syncs the configuration attributes of
     objects that can be changed at runtime."""
 
-    def __init__(self, cfg, vpp_api_socket='/run/vpp/api.sock', vpp_json_dir='/usr/share/vpp/api/'):
+    def __init__(
+        self,
+        cfg,
+        vpp_api_socket="/run/vpp/api.sock",
+        vpp_json_dir="/usr/share/vpp/api/",
+    ):
         self.logger = logging.getLogger("vppcfg.reconciler")
         self.logger.addHandler(logging.NullHandler())
 

--- a/vppcfg
+++ b/vppcfg
@@ -86,6 +86,22 @@ def main():
         type=str,
         help="""Output file for YAML config, default stdout""",
     )
+    dump_p.add_argument(
+        "-j",
+        "--vpp-json-dir",
+        dest="vpp_json_dir",
+        required=False,
+        type=str,
+        help="""Directory where VPP API JSON files are located""",
+    )
+    dump_p.add_argument(
+        "-a",
+        "--vpp-api-socket",
+        dest="vpp_api_socket",
+        required=False,
+        type=str,
+        help="""Pathname of VPP API socket file""",
+    )
 
     plan_p = subparsers.add_parser(
         "plan",
@@ -115,6 +131,22 @@ def main():
         type=str,
         help="""Output file for VPP CLI commands, default stdout""",
     )
+    plan_p.add_argument(
+        "-j",
+        "--vpp-json-dir",
+        dest="vpp_json_dir",
+        required=False,
+        type=str,
+        help="""Directory where VPP API JSON files are located""",
+    )
+    plan_p.add_argument(
+        "-a",
+        "--vpp-api-socket",
+        dest="vpp_api_socket",
+        required=False,
+        type=str,
+        help="""Pathname of VPP API socket file""",
+    )
 
     apply_p = subparsers.add_parser(
         "apply", help="apply changes from current VPP dataplane to target config"
@@ -134,6 +166,22 @@ def main():
         type=str,
         help="""YAML configuration file for vppcfg""",
     )
+    apply_p.add_argument(
+        "-j",
+        "--vpp-json-dir",
+        dest="vpp_json_dir",
+        required=False,
+        type=str,
+        help="""Directory where VPP API JSON files are located""",
+    )
+    apply_p.add_argument(
+        "-a",
+        "--vpp-api-socket",
+        dest="vpp_api_socket",
+        required=False,
+        type=str,
+        help="""Pathname of VPP API socket file""",
+    )
 
     args = parser.parse_args()
     if not args.command:
@@ -150,8 +198,14 @@ def main():
         format="[%(levelname)-8s] %(name)s.%(funcName)s: %(message)s", level=level
     )
 
+    opt_kwargs = {}
+    if args.vpp_json_dir:
+        opt_kwargs["vpp_json_dir"] = args.vpp_json_dir
+    if args.vpp_api_socket:
+        opt_kwargs["vpp_api_socket"] = args.vpp_api_socket
+
     if args.command == "dump":
-        dumper = Dumper()
+        dumper = Dumper(**opt_kwargs)
         if not dumper.readconfig():
             logging.error("Could not retrieve config from VPP")
             sys.exit(-7)
@@ -175,7 +229,7 @@ def main():
     if args.command == "check":
         sys.exit(0)
 
-    reconciler = Reconciler(cfg)
+    reconciler = Reconciler(cfg, **opt_kwargs)
     if not reconciler.vpp.readconfig():
         sys.exit(-3)
 


### PR DESCRIPTION
- allow vppcfg to communicate with a vpp running from a dev workspace
  and/or non-default vpp api file locations (e.g. vpp run via 'make test')

Signed-off-by: Dave Wallace <dwallacelf@gmail.com>