### PR TITLE
build: enable unit tests as part of build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ WIPE=dist $(VPPCFG).egg-info .pybuild debian/vppcfg debian/vppcfg.*.log
 WIPE+=debian/vppcfg.*.debhelper debian/.debhelper debian/files
 WIPE+=debian/vppcfg.substvars
 WHL_INSTALL=dist/$(VPPCFG)-$(VERSION)-py3-none-any.whl
+TESTS=$(VPPCFG)/tests.py
 
 .PHONY: build
 build:
@@ -28,6 +29,10 @@ pkg-deb:
 .PHONY: check-style
 check-style:
 	PYTHONPATH=./$(VPPCFG) pylint ./$(VPPCFG)
+
+.PHONY: test
+test:
+	PYTHONPATH=./$(VPPCFG) $(PYTHON) $(TESTS)
 
 .PHONY: uninstall
 uninstall:

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,3 @@
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild --with systemd
-
-# TODO: fix test.py to that unit tests can be automagically called.
-override_dh_auto_test:

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
             "vppcfg = vppcfg.vppcfg:main",
         ]
     },
+    test_suite="vppcfg.config",
     package_data={"vppcfg": ["*.yaml"]},
 )


### PR DESCRIPTION
Enabling the unit tests as part of the pip and debian builds.

Signed-off-by: Ray Kinsella <mdr@ashroe.eu>