### PR TITLE
vppapi: Use VPPApiJSONFiles instead of reinventing the wheel.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
         'importlib-metadata; python_version == "3.8"',
         "yamale",
         "netaddr",
-        "ipaddress",
         "vpp_papi",
     ],
     packages=["vppcfg", "vppcfg/config", "vppcfg/vpp"],

--- a/vppcfg/vpp/applier.py
+++ b/vppcfg/vpp/applier.py
@@ -30,7 +30,7 @@ class Applier(VPPApi):
     def __init__(
         self,
         vpp_api_socket="/run/vpp/api.sock",
-        vpp_json_dir="/usr/share/vpp/api/",
+        vpp_json_dir=None,
         clientname="vppcfg",
     ):
         VPPApi.__init__(self, vpp_api_socket, vpp_json_dir, clientname)

--- a/vppcfg/vpp/dumper.py
+++ b/vppcfg/vpp/dumper.py
@@ -34,7 +34,7 @@ class Dumper(VPPApi):
     def __init__(
         self,
         vpp_api_socket="/run/vpp/api.sock",
-        vpp_json_dir="/usr/share/vpp/api/",
+        vpp_json_dir=None,
         clientname="vppcfg",
     ):
         VPPApi.__init__(self, vpp_api_socket, vpp_json_dir, clientname)

--- a/vppcfg/vpp/reconciler.py
+++ b/vppcfg/vpp/reconciler.py
@@ -42,7 +42,7 @@ class Reconciler:
         self,
         cfg,
         vpp_api_socket="/run/vpp/api.sock",
-        vpp_json_dir="/usr/share/vpp/api/",
+        vpp_json_dir=None,
     ):
         self.logger = logging.getLogger("vppcfg.reconciler")
         self.logger.addHandler(logging.NullHandler())

--- a/vppcfg/vpp/vppapi.py
+++ b/vppcfg/vpp/vppapi.py
@@ -23,7 +23,7 @@ import fnmatch
 import logging
 import socket
 import time
-from vpp_papi import VPPApiClient
+from vpp_papi import VPPApiClient, VPPApiJSONFiles
 
 
 class VPPApi:
@@ -32,11 +32,14 @@ class VPPApi:
     def __init__(
         self,
         vpp_api_socket="/run/vpp/api.sock",
-        vpp_json_dir="/usr/share/vpp/api/",
+        vpp_json_dir=None,
         clientname="vppcfg",
     ):
         self.logger = logging.getLogger("vppcfg.vppapi")
         self.logger.addHandler(logging.NullHandler())
+
+        if vpp_json_dir is None:
+            vpp_json_dir = VPPApiJSONFiles.find_api_dir([])
 
         if not os.path.exists(vpp_api_socket):
             self.logger.error(f"VPP api socket file not found: {vpp_api_socket}")
@@ -58,11 +61,7 @@ class VPPApi:
             return True
 
         # construct a list of all the json api files
-        jsonfiles = []
-        for root, _dirnames, filenames in os.walk(self.vpp_json_dir):
-            for filename in fnmatch.filter(filenames, "*.api.json"):
-                jsonfiles.append(os.path.join(root, filename))
-
+        jsonfiles = VPPApiJSONFiles.find_api_files(api_dir=self.vpp_json_dir)
         if not jsonfiles:
             self.logger.error("no json api files found")
             return False


### PR DESCRIPTION
Hey Pim!
I've recently started packaging VPP for NixOS in [my personal repository](https://github.com/vifino/nix-geht).
Along with it `vpp_papi` and now `vppcfg`. However, NixOS being NixOS, it certainly has some non-standard paths.

I figured out that `vpp_papi` already has a JSON API loader, including a utility to search for the proper location.
So I patched that to return the proper Nix Store path.
But to my surprise, `vppcfg` didn't use that class or functionality at all. So I rectified this by removing the custom simplified JSON API file finder and instead made `vppcfg` use the `vpp_papi` provided `VPPApiJSONFiles`.

It shouldn't break any functionality. `VPPApiJSONFiles` is provided for [at least 3 years now](https://github.com/FDio/vpp/commit/edfe2c0079a756f5fb1108037c39450e3521c8bd).

EDIT: Oh, yeah, I also removed `ipaddress` from the dependencies - it's included in Python 3.