### PR TITLE
Update changelog to put 0.0.6 in the right place

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,13 +1,13 @@
-vppcfg (0.0.5) unstable; urgency=low
-
-  Feature release:
-    * Allow for 'unnumbered' interfaces.
- -- Pim van Pelt <pim@ipng.nl>  Sun, 07 APr 2024 12:15:00 +0000
 vppcfg (0.0.6) unstable; urgency=low
 
   Feature release:
     * Re-order the interfaces: loopbacks before phy/sub-int
 
+ -- Pim van Pelt <pim@ipng.nl>  Sun, 07 APr 2024 12:15:00 +0000
+vppcfg (0.0.5) unstable; urgency=low
+
+  Feature release:
+    * Allow for 'unnumbered' interfaces.
  -- Pim van Pelt <pim@ipng.nl>  Sun, 07 APr 2024 12:15:00 +0000
 vppcfg (0.0.4) unstable; urgency=low
 


### PR DESCRIPTION
Otherwise `make pkg-deb` will build packages for 0.0.5.