### PR TITLE
Update debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: vppcfg
 Section: python
 Priority: extra
 Maintainer: Ray Kinsella <mdr@ashroe.eu>
-Build-Depends: debhelper (>= 9), python3-all, dh-python
+Build-Depends: debhelper (>= 9), python3-all, python3-setuptools, dh-python
 Standards-Version: 3.9.5
 
 Package: vppcfg
 Architecture: any
-Pre-Depends: dpkg (>= 1.16.1), python3 (>=3.8), ${misc:Pre-Depends}
-Depends: python3-netaddr, python3-ipaddr, ${misc:Depends}
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${python3:Depends}, python3-importlib-metadata, python3-yamale, python3-vpp-api
 Description: A configuration tool for FD.io VPP

--- a/vppcfg/config/test_acl.py
+++ b/vppcfg/config/test_acl.py
@@ -130,28 +130,28 @@ class TestACLMethods(unittest.TestCase):
         for s in ["192.0.2.1", "192.0.2.1/24", "2001:db8::1", "2001:db8::1/64"]:
             l = acl.get_network_list(self.cfg, s)
             self.assertIsInstance(l, list)
-            self.assertEquals(1, len(l))
+            self.assertEqual(1, len(l))
             n = l[0]
 
         l = acl.get_network_list(self.cfg, "trusted")
         self.assertIsInstance(l, list)
-        self.assertEquals(5, len(l))
+        self.assertEqual(5, len(l))
 
         l = acl.get_network_list(self.cfg, "trusted", want_ipv6=False)
         self.assertIsInstance(l, list)
-        self.assertEquals(2, len(l))
+        self.assertEqual(2, len(l))
 
         l = acl.get_network_list(self.cfg, "trusted", want_ipv4=False)
         self.assertIsInstance(l, list)
-        self.assertEquals(3, len(l))
+        self.assertEqual(3, len(l))
 
         l = acl.get_network_list(self.cfg, "trusted", want_ipv4=False, want_ipv6=False)
         self.assertIsInstance(l, list)
-        self.assertEquals(0, len(l))
+        self.assertEqual(0, len(l))
 
         l = acl.get_network_list(self.cfg, "pl-notexist")
         self.assertIsInstance(l, list)
-        self.assertEquals(0, len(l))
+        self.assertEqual(0, len(l))
 
     def test_network_list_has_family(self):
         l = acl.get_network_list(self.cfg, "trusted")

--- a/vppcfg/config/test_prefixlist.py
+++ b/vppcfg/config/test_prefixlist.py
@@ -79,22 +79,22 @@ class TestACLMethods(unittest.TestCase):
     def test_get_network_list(self):
         l = prefixlist.get_network_list(self.cfg, "trusted")
         self.assertIsInstance(l, list)
-        self.assertEquals(5, len(l))
+        self.assertEqual(5, len(l))
 
         l = prefixlist.get_network_list(self.cfg, "trusted", want_ipv6=False)
         self.assertIsInstance(l, list)
-        self.assertEquals(2, len(l))
+        self.assertEqual(2, len(l))
 
         l = prefixlist.get_network_list(self.cfg, "trusted", want_ipv4=False)
         self.assertIsInstance(l, list)
-        self.assertEquals(3, len(l))
+        self.assertEqual(3, len(l))
 
         l = prefixlist.get_network_list(
             self.cfg, "trusted", want_ipv4=False, want_ipv6=False
         )
         self.assertIsInstance(l, list)
-        self.assertEquals(0, len(l))
+        self.assertEqual(0, len(l))
 
         l = prefixlist.get_network_list(self.cfg, "pl-notexist")
         self.assertIsInstance(l, list)
-        self.assertEquals(0, len(l))
+        self.assertEqual(0, len(l))


### PR DESCRIPTION
Also replaced a few places where `assertEquals` was used instead of `assertEqual`.
Tested by running this script, which does a clean build inside a Docker container and exports the `.deb` binary as a result:

```
#!/bin/bash
docker buildx build --output=. --file=- --progress=plain https://github.com/lion7/vppcfg.git <<EOF
FROM ubuntu:noble AS base

ENV DEBIAN_FRONTEND=noninteractive
RUN apt-get update && apt-get install build-essential debhelper apt-utils curl wget -y

WORKDIR /package
ENTRYPOINT ["dpkg-buildpackage"]
CMD ["-us", "-uc"]

FROM base AS build
# install build tooling
RUN apt-get update && apt-get install python3-all python3-setuptools dh-python -y
# install vppcfg dependencies
RUN apt-get update && apt-get install python3-requests python3-importlib-metadata python3-netaddr -y
# python3-yamale is not (yet) available in any official repository, so install it manually
RUN wget http://ftp.nl.debian.org/debian/pool/main/y/yamale/python3-yamale_5.2.1-1_all.deb && apt-get install ./python3-yamale_5.2.1-1_all.deb -y
# install the VPP Python API from the official fd.io repository
RUN curl -s https://packagecloud.io/install/repositories/fdio/master/script.deb.sh | bash && apt-get update && apt-get install python3-vpp-api -y
# build context should be a shallow copy of the git repo
COPY . .
# build the .deb binary
RUN dpkg-buildpackage -uc -us -b

FROM scratch AS package
# copy only the .deb binary into a scratch container, so it's the only file exported by the --output flag
COPY --from=build /vppcfg*.deb /
EOF
```